### PR TITLE
feat(author): added way to set an comment author

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ author:comment;
 canbe multiline, too
 ```
 
+## How an author is set
+
+The current author can be set as follows
+
+```
+var Comments = require('bpmn-js-embedded-comments');
+
+Comments.author.setAuthor('My Name');
+```
+
 ## License
 
 MIT

--- a/assets/comments.css
+++ b/assets/comments.css
@@ -35,6 +35,13 @@
   position: relative;
 }
 
+.comments-overlay .comment .author {
+  font-weight: bold;
+}
+.comments-overlay .comment .author::after {
+  content: ':';
+}
+
 .comments-overlay .comment .delete {
   position: absolute;
   right: 3px;

--- a/lib/author.js
+++ b/lib/author.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var commentAuthor = '';
+
+module.exports.setAuthor = function(author) {
+	commentAuthor = author;
+}
+
+module.exports.getAuthor = function() {
+	return commentAuthor;
+}

--- a/lib/comments.js
+++ b/lib/comments.js
@@ -5,7 +5,8 @@ var $ = require('jquery');
 var _ = require('lodash');
 
 
-var util = require('./util');
+var util = require('./util'),
+    author = require('./author');
 
 
 function Comments(eventBus, overlays, bpmnjs) {
@@ -55,6 +56,11 @@ function Comments(eventBus, overlays, bpmnjs) {
       comments.forEach(function(val) {
         var $comment = $(Comments.COMMENT_HTML);
 
+        if(val[0] !== '') {
+          $comment.find('[data-author]').text(val[0]);
+        } else {
+          $comment.find('[data-author]').css('display', 'none');
+        }
         $comment.find('[data-text]').text(val[1]);
         $comment.find('[data-delete]').click(function(e) {
 
@@ -82,7 +88,7 @@ function Comments(eventBus, overlays, bpmnjs) {
         var comment = $textarea.val();
 
         if (comment) {
-          util.addComment(element, '', comment);
+          util.addComment(element, author.getAuthor(), comment);
           $textarea.val('');
           renderComments();
         }
@@ -145,7 +151,7 @@ Comments.OVERLAY_HTML =
 
 Comments.COMMENT_HTML =
   '<div class="comment">' +
-    '<div data-text /><a href class="delete icon-delete" data-delete></a>' +
+    '<div><span class="author" data-author /> <span data-text /></div><a href class="delete icon-delete" data-delete></a>' +
   '</div>';
 
 module.exports = Comments;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   __init__: [ 'comments' ],
-  'comments': [ 'type', require('./comments') ]
+  'comments': [ 'type', require('./comments') ],
+  'author': require('./author')
 };


### PR DESCRIPTION
This commit will add support to set the current author who is writing the comments.

```
var Comments = require('bpmn-js-embedded-comments');

Comments.author.setAuthor('My Name');
```

Furthermore authors will be shown in the UI in the manner "Author: comment text".
