### PR TITLE
Improve types for comments API

### DIFF
--- a/lib/comments.js
+++ b/lib/comments.js
@@ -6,12 +6,21 @@ import {
   addComment
 } from './util';
 
+
+/**
+ * @typedef { import('./types.js').Comment } Comment
+ */
+
+
 var COMMENT_HTML =
   '<div class="comment">' +
     '<div data-text></div><a href class="delete icon-delete" data-delete></a>' +
   '</div>';
 
+
 export default function Comments(eventBus, overlays, bpmnjs, translate) {
+  var self = this;
+
   function toggleCollapse(element) {
 
     var o = overlays.get({ element: element, type: 'comments' })[0];
@@ -56,15 +65,14 @@ export default function Comments(eventBus, overlays, bpmnjs, translate) {
       comments.forEach(function(val) {
         var $comment = $(COMMENT_HTML);
 
-        $comment.find('[data-text]').text(val[1]);
+        $comment.find('[data-text]').text(val.text);
         $comment.find('[data-delete]').click(function(e) {
 
           e.preventDefault();
 
-          removeComment(element, val);
-          eventBus.fire('comments.removed', { element: element, comment: val });
+          self.removeComment(element, val);
           renderComments();
-          $textarea.val(val[1]);
+          $textarea.val(val.text);
         });
 
         $comments.append($comment);
@@ -81,11 +89,16 @@ export default function Comments(eventBus, overlays, bpmnjs, translate) {
       if (e.which === 13 && !e.shiftKey) {
         e.preventDefault();
 
-        var comment = $textarea.val();
+        var text = $textarea.val();
 
-        if (comment) {
-          addComment(element, '', comment);
-          eventBus.fire('comments.added', { element: element, comment: comment });
+        if (text) {
+
+          const comment = {
+            author: '',
+            text
+          };
+
+          self.addComment(element, comment);
           $textarea.val('');
           renderComments();
         }
@@ -128,18 +141,18 @@ export default function Comments(eventBus, overlays, bpmnjs, translate) {
         toggleCollapse(c.element);
       }
     });
-
   };
+
   this.getComments = function(element) {
     return getComments(element);
   };
 
-  this.addComment = function(element, author, text) {
-    addComment(element, author, text);
+  this.addComment = function(element, comment) {
+    addComment(element, comment);
 
     eventBus.fire('comments.added', {
       element: element,
-      comment: [ author, text ]
+      comment
     });
   };
 

--- a/lib/comments.js
+++ b/lib/comments.js
@@ -19,9 +19,10 @@ var COMMENT_HTML =
 
 
 export default function Comments(eventBus, overlays, bpmnjs, translate) {
+
   var self = this;
 
-  function toggleCollapse(element) {
+  function toggleCollapse(element, collapse) {
 
     var o = overlays.get({ element: element, type: 'comments' })[0];
 
@@ -29,7 +30,7 @@ export default function Comments(eventBus, overlays, bpmnjs, translate) {
 
     if ($overlay) {
 
-      var expanded = $overlay.is('.expanded');
+      var expanded = typeof collapse !== 'undefined' ? !collapse : $overlay.is('.expanded');
 
       eventBus.fire('comments.toggle', { element: element, active: !expanded });
 
@@ -136,10 +137,7 @@ export default function Comments(eventBus, overlays, bpmnjs, translate) {
   this.collapseAll = function() {
 
     overlays.get({ type: 'comments' }).forEach(function(c) {
-      var html = c.html;
-      if (html.is('.expanded')) {
-        toggleCollapse(c.element);
-      }
+      toggleCollapse(c.element, true);
     });
   };
 

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,0 +1,4 @@
+export declare type Comment = {
+  author: string,
+  text: string
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef { import('./types.js').Comment } Comment
+ */
+
+
 export function _getCommentsElement(element, create) {
 
   var bo = element.businessObject;
@@ -20,6 +25,11 @@ export function _getCommentsElement(element, create) {
   return comments;
 }
 
+/**
+ * @param {DiagramElement} element
+ *
+ * @return {Comment[]} comments
+ */
 export function getComments(element) {
   var doc = _getCommentsElement(element);
 
@@ -28,42 +38,47 @@ export function getComments(element) {
   } else {
     return doc.text.split(/;\r?\n;/).map(function(str) {
       return str.split(/:/, 2);
-    });
+    }).map(([ author, text ]) => ({ author, text }));
   }
 }
 
+/**
+ * @param {DiagramElement} element
+ * @param {Comment[]} comments
+ */
 export function setComments(element, comments) {
   var doc = _getCommentsElement(element, true);
 
   var str = comments.map(function(c) {
-    return c.join(':');
+    return [ c.author, c.text ].join(':');
   }).join(';\n;');
 
   doc.text = str;
 }
 
-export function addComment(element, author, str) {
+/**
+ * @param {DiagramElement} element
+ * @param {Comment} comment
+ */
+export function addComment(element, comment) {
   var comments = getComments(element);
 
-  comments.push([ author, str ]);
+  comments.push(comment);
 
   setComments(element, comments);
 }
 
+/**
+ * @param {DiagramElement} element
+ * @param {Comment} comment
+ */
 export function removeComment(element, comment) {
   var comments = getComments(element);
 
-  var idx = -1;
-
-  comments.some(function(c, i) {
-
-    var matches = c[0] === comment[0] && c[1] === comment[1];
-
-    if (matches) {
-      idx = i;
-    }
-
-    return matches;
+  var idx = comments.findIndex(c => {
+    return (
+      c.author === comment.author && c.text === comment.text
+    );
   });
 
   if (idx !== -1) {

--- a/test/spec/commentsSpec.js
+++ b/test/spec/commentsSpec.js
@@ -77,8 +77,8 @@ describe('comments integration', function() {
 
     const subProcess = elementRegistry.get('SubProcess_1');
 
-    addComment(subProcess, '', 'This is a subprocess');
-    addComment(subProcess, 'ME', 'This is another comment\n(with line breaks)');
+    addComment(subProcess, { author: '', text: 'This is a subprocess' });
+    addComment(subProcess, { author: 'ME', text: 'This is another comment\n(with line breaks)' });
 
     const expectedXML =
       '<bpmn2:subProcess id="SubProcess_1" name="Sub Process 1">' +
@@ -95,7 +95,7 @@ describe('comments integration', function() {
   });
 
 
-  it('should expose comments API via DI', async function() {
+  it('should expose comments API', async function() {
 
     // given
     const viewer = new Viewer({
@@ -112,84 +112,95 @@ describe('comments integration', function() {
 
     const task = elementRegistry.get('Task_1');
 
-    addComment(task, 'Drin', 'Hello');
+    comments.addComment(task, { author: 'Drin', text: 'Hello' });
 
     // when
     const result = comments.getComments(task);
 
     // then
-    expect(result.length).to.equal(1);
-    expect(result[0][1]).to.equal('Hello');
+    expect(result).to.eql([
+      { author: 'Drin', text: 'Hello' }
+    ]);
   });
 
 
-  it('should fire comments.added event', async function() {
+  describe('should emit events', function() {
 
-    // given
-    const viewer = new Viewer({
-      container: container,
-      additionalModules: [ commentsModule ]
+    it('<comments.added> on add', async function() {
+
+      // given
+      const viewer = new Viewer({
+        container: container,
+        additionalModules: [ commentsModule ]
+      });
+
+      const xml = require('./simple.bpmn');
+
+      await viewer.importXML(xml);
+
+      const eventBus = viewer.get('eventBus');
+      const comments = viewer.get('comments');
+      const elementRegistry = viewer.get('elementRegistry');
+
+      const task = elementRegistry.get('Task_1');
+
+      let fired = false;
+
+      eventBus.on('comments.added', function(event) {
+        fired = true;
+
+        expect(event.element).to.equal(task);
+        expect(event.comment).to.eql({ author: 'Drin', text: 'Test' });
+      });
+
+      // when
+      comments.addComment(task, { author: 'Drin', text: 'Test' });
+
+      // then
+      expect(fired).to.be.true;
     });
 
-    const xml = require('./simple.bpmn');
 
-    await viewer.importXML(xml);
+    it('<comments.removed> on removal', async function() {
 
-    const eventBus = viewer.get('eventBus');
-    const comments = viewer.get('comments');
-    const elementRegistry = viewer.get('elementRegistry');
+      // given
+      const viewer = new Viewer({
+        container: container,
+        additionalModules: [ commentsModule ]
+      });
 
-    const task = elementRegistry.get('Task_1');
+      const xml = require('./simple.bpmn');
 
-    let fired = false;
+      await viewer.importXML(xml);
 
-    eventBus.on('comments.added', function(e) {
-      fired = true;
-      expect(e.element).to.equal(task);
+      const eventBus = viewer.get('eventBus');
+      const comments = viewer.get('comments');
+      const elementRegistry = viewer.get('elementRegistry');
+
+      const task = elementRegistry.get('Task_1');
+
+      addComment(task, { author: '', text: 'To delete' });
+
+      const existing = comments.getComments(task)[0];
+
+      let fired = false;
+
+      eventBus.on('comments.removed', function(event) {
+        fired = true;
+
+        expect(event.element).to.eql(task);
+        expect(event.comment).to.eql({ author: '', text: 'To delete' });
+      });
+
+      // when
+      comments.removeComment(task, existing);
+
+      // then
+      expect(fired).to.be.true;
     });
 
-    // when
-    comments.addComment(task, 'Drin', 'Test');
-
-    // then
-    expect(fired).to.be.true;
   });
 
-
-  it('should fire comments.removed event', async function() {
-
-    // given
-    const viewer = new Viewer({
-      container: container,
-      additionalModules: [ commentsModule ]
-    });
-
-    const xml = require('./simple.bpmn');
-
-    await viewer.importXML(xml);
-
-    const eventBus = viewer.get('eventBus');
-    const comments = viewer.get('comments');
-    const elementRegistry = viewer.get('elementRegistry');
-
-    const task = elementRegistry.get('Task_1');
-
-    addComment(task, '', 'To delete');
-
-    const existing = comments.getComments(task)[0];
-
-    let fired = false;
-
-    eventBus.on('comments.removed', function() {
-      fired = true;
-    });
-
-    // when
-    comments.removeComment(task, existing);
-
-    // then
-    expect(fired).to.be.true;
-  });
 });
 
 // helpers ///////////////


### PR DESCRIPTION
### Proposed Changes

Follow-up to https://github.com/bpmn-io/bpmn-js-embedded-comments/pull/12, exposing comments as well known elements (`{ author: string, text: string }`) over the past array form - what is part of an API should be reasonably typed.


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
